### PR TITLE
Update conjur conf via evoke

### DIFF
--- a/1_master/enable_dap_node_for_k8s.sh
+++ b/1_master/enable_dap_node_for_k8s.sh
@@ -78,9 +78,8 @@ add_new_authenticator() {
   set -e
 
   if [[ "$authn_str" == "" ]]; then	# If no authenticators specified...
-					# add authenticators to conjur.conf
-    echo "CONJUR_AUTHENTICATORS=\"${CONJUR_AUTHENTICATORS}\"" >> temp.conf
-    docker exec -i $DAP_NODE_CONTAINER_NAME dd of=/opt/conjur/etc/conjur.conf < temp.conf
+		# add authenticators to conjur.conf
+    docker exec -i $DAP_NODE_CONTAINER_NAME sh -c "evoke variable set CONJUR_AUTHENTICATORS \"$CONJUR_AUTHENTICATORS\""
   else
 					# else replace line in conjur.conf
     docker exec $DAP_NODE_CONTAINER_NAME \

--- a/config/dap.config
+++ b/config/dap.config
@@ -33,7 +33,7 @@ export CONJUR_MASTER_PORT=443
 export CONJUR_FOLLOWER_PORT=444  # for follower on master host only
 export CONJUR_MASTER_URL=https://$CONJUR_MASTER_HOST_NAME:$CONJUR_MASTER_PORT
 export CONJUR_ACCOUNT=dev
-export CONJUR_ADMIN_PASSWORD=Cyberark1	 # password to set for default admin user
+export CONJUR_ADMIN_PASSWORD=MySecretP@ss1	 # password to set for default admin user
 
 #===============================================================
 # Image tags in local docker daemon - precheck.sh validates if loaded or not


### PR DESCRIPTION
This PR utilizes `evoke variable set` instead of appending the `conjur.conf` using `>>`. This is important to ensure the `conjur.conf` stays in the appropriate format. 